### PR TITLE
Feature: Add rescue when query NFT data from chain

### DIFF
--- a/app/controllers/api/v1/artworks_controller.rb
+++ b/app/controllers/api/v1/artworks_controller.rb
@@ -6,7 +6,11 @@ class Api::V1::ArtworksController < Api::V1::BaseController
         nft_list = []
 
         Artwork.all.each do |artwork|
-            nft_list << cli.nft_data(artwork.id)
+            begin
+                nft_list << cli.nft_data(artwork.id)
+            rescue
+                # just pass for now
+            end
         end
 
         render json: {data: nft_list}, status: 200


### PR DESCRIPTION
## Story

ปัจจุบัน เมื่อสร้าง NFT ไม่สำเร็จ จะทำให้ NFT ชิ้นใหม่ไม่ถูก save ใน chain (แต่ save ใน database ไปแล้ว) ดังนั้น เวลา GET หน้า home จะทำให้เกิดการ error เนื่องจาก query NFT จากใน chain ไม่ได้(เพราะมันไม่มี ไม่ถูก save)

ข้อเสียคือ เมื่อมี NFT พังอันเดียว อันอื่นๆจะ query ไม่ได้เหมือนกันทั้งหมด ทำให้หน้า home GET ไม่ได้ทั้งหน้า ทั้งๆที่ ปัญหาเกิดจาก NFT สร้างใหม่แค่ตัวเดียว(ถ้าตัดตัวที่มีปัญหาตัวอื่นยัง GET ได้เหมือนเดิม) ดังนั้นเลยเพิ่ม condition เข้าไปดังนี้

ต่อไปนี้ หน้า home จะ GET ได้เสมอ ไม่ว่ากรณีใดก็ตาม แต่ถ้ามี NFT ที่เกิด error(สร้างไม่ได้) NFT นั้นก็จะแค่ไม่แสดงใน home แต่อันที่ไม่มีปัญหาจะแสดงเหมือนเดิม